### PR TITLE
fix: Solución definitiva a la subida a través de Filepond

### DIFF
--- a/resources/views/evidence/createandedit.blade.php
+++ b/resources/views/evidence/createandedit.blade.php
@@ -227,8 +227,10 @@
                     server: {
                         url: '{{route('upload.process',Instantiation::instance())}}',
                         process: {
-                            url: '/',
-                            method: 'POST'
+                            method: 'POST',
+                            headers: {
+                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                            },
                         },
                         load: (source, load, error, progress, abort, headers) => {
 

--- a/resources/views/importexport/import.blade.php
+++ b/resources/views/importexport/import.blade.php
@@ -174,8 +174,10 @@
                     server: {
                         url: '{{route('xls.upload.process',Instantiation::instance())}}',
                         process: {
-                            url: '/',
-                            method: 'POST'
+                            method: 'POST',
+                            headers: {
+                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                            },
                         },
                         load: (source, load, error, progress, abort, headers) => {
 


### PR DESCRIPTION
Debido a la documentación poco clara de Filepond, he descubierto (casi por casualidad) las dos líneas exactas para forzar a que los archivos se manden por POST, dado que es IMPOSIBLE que funcione por GET