### PR TITLE
fix: Corregido problema en editar actas

### DIFF
--- a/resources/views/meeting/minutes_edit.blade.php
+++ b/resources/views/meeting/minutes_edit.blade.php
@@ -28,6 +28,8 @@
 
                         <input type="hidden" name="meeting_id" value="{{$meeting_minutes->meeting->id}}"/>
 
+                        <input type="hidden" name="meeting_minutes_id" value="{{$meeting_minutes->id}}"/>
+
                         <input type="hidden" name="points_json" id="points_json"/>
 
                         <h4>Información de la reunión</h4>

--- a/resources/views/meeting/minutes_template.blade.php
+++ b/resources/views/meeting/minutes_template.blade.php
@@ -86,7 +86,9 @@
 
             <tr>
                 <td>Hora fin</td>
-                <td>{{ \Carbon\Carbon::parse($meeting_minutes->meeting->datetime)->addHours($meeting_minutes->meeting->hours)->format('H:i') }}</td>
+                <td>
+                    {{ \Carbon\Carbon::parse($meeting_minutes->meeting->datetime)->addHours(Time::complex_shape_hours($meeting_minutes->meeting->hours))->addMinutes(Time::complex_shape_minutes($meeting_minutes->meeting->hours))->format('H:i') }}
+                </td>
             </tr>
 
             <tr>


### PR DESCRIPTION
- Editar un acta arrojaba un error 404 debido a un parámetro perdido.
- No se sumaban los minutos en el PDF de las actas (pero sí en el sistema)