### PR TITLE
fix: Error de fecha en plantilla de acta

### DIFF
--- a/resources/views/meeting/minutes_template.blade.php
+++ b/resources/views/meeting/minutes_template.blade.php
@@ -76,7 +76,7 @@
 
             <tr>
                 <td>Fecha</td>
-                <td>{{\Carbon\Carbon::now()->format('d/m/Y')}}</td>
+                <td>{{ \Carbon\Carbon::parse($meeting_minutes->meeting->datetime)->format('d/m/Y') }}</td>
             </tr>
 
             <tr>


### PR DESCRIPTION
Se escribía la fecha actual en lugar de la fecha de la reunión