### PR TITLE
fix: Error en vista de "Gestionar evidencias"

### DIFF
--- a/resources/views/components/evidencestatus.blade.php
+++ b/resources/views/components/evidencestatus.blade.php
@@ -23,7 +23,7 @@
 
 @if($evidence->status == "REJECTED")
     <div class="progress progress-sm">
-        <div class="progress-bar bg-gradient-warning" role="progressbar" data-toggle="tooltip" data-placement="right" title="Rechazada: {{$evidence->reason_rejection->reason}}" aria-volumenow="100" aria-volumemin="0" aria-volumemax="100" style="width: 100%">
+        <div class="progress-bar bg-gradient-warning" role="progressbar" data-toggle="tooltip" data-placement="right" title="Rechazada: {{$evidence->reason_rejection?->reason}}" aria-volumenow="100" aria-volumemin="0" aria-volumemax="100" style="width: 100%">
         </div>
     </div>
 @endif


### PR DESCRIPTION
Existía una evidencia rechazada sin un motivo. Esto hace que salte una excepción de tipo NullException al no existir la relación entre la evidencia y la entidad "reason_rejecton". 
La solución ha sido usar el operador Null safe de PHP 8