### PR TITLE
fix: Corregido error visual en las pruebas de una evidencia

### DIFF
--- a/resources/views/evidence/view.blade.php
+++ b/resources/views/evidence/view.blade.php
@@ -96,7 +96,7 @@
                         @foreach($evidence->proofs as $proof)
 
                             <div class="col-auto mt-3">
-                                <a class="btn btn-default btn-sm" href="{{route('proof.download',['instance' => $instance, 'id' => $proof->id])}}">
+                                <a style="margin-bottom: 10px" class="btn btn-default btn-sm" href="{{route('proof.download',['instance' => $instance, 'id' => $proof->id])}}">
                                     <i class="fas fa-download"></i>
                                     {{$proof->file->name}} ({{$proof->file->sizeForHuman()}})
                                 </a>

--- a/resources/views/profile/profile_evidence_view.blade.php
+++ b/resources/views/profile/profile_evidence_view.blade.php
@@ -73,7 +73,7 @@
 
                             @foreach($evidence->proofs as $proof)
 
-                                <a class="btn btn-primary btn-sm" href="{{route('proof.download',['instance' => $instance, 'id' => $proof->id])}}">
+                                <a style="margin-bottom: 10px" class="btn btn-primary btn-sm" href="{{route('proof.download',['instance' => $instance, 'id' => $proof->id])}}">
                                     <i class="fas fa-download"></i>
                                     {{$proof->file->name}} ({{$proof->file->sizeForHuman()}})
                                 </a>


### PR DESCRIPTION
Los botones de descargas aparecían sin separación