### PR TITLE
fix: Arreglado problema de escape de entidades HTML

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -135,7 +135,7 @@
                                             @forelse(\App\Models\Event::all() as $event)
 
                                                 <div class="callout callout-info">
-                                                    <h5>{{$event->name}}</h5>
+                                                    <h5>{!! $event->name !!}</h5>
                                                     <a target="_blank" href="{{$event->url}}">{{$event->url}}</a>
 
                                                     <p>{!! $event->description !!}</p>


### PR DESCRIPTION
Algunos nombres de eventos tienen caracteres HTML, ahora se interpretan