### PR TITLE
feat: Carga de asistencias por evento

### DIFF
--- a/resources/views/eventbrite/attendee_list.blade.php
+++ b/resources/views/eventbrite/attendee_list.blade.php
@@ -21,12 +21,6 @@
             @if(!\Carbon\Carbon::now()->gt(\Config::attendee_timestamp()))
             <div class="row mb-3">
                 <div class="col-lg-4 mt-1">
-                    <a href="{{route('registercoordinator.attendee.load',['instance' => $instance])}}"
-                       class="btn btn-primary btn-block" role="button">
-                        <i class="fas fa-cloud-download-alt"></i> &nbsp;Cargar asistencias desde Eventbrite</a>
-                </div>
-
-                <div class="col-lg-4 mt-1">
                     <a href="{{route('registercoordinator.attendee.export',['instance' => $instance])}}"
                        class="btn btn-info btn-block" role="button">
                         <i class="fas fa-file-export"></i> &nbsp;Exportar asistencias</a>

--- a/resources/views/eventbrite/event_list.blade.php
+++ b/resources/views/eventbrite/event_list.blade.php
@@ -56,6 +56,7 @@
                             <th class="d-none d-sm-none d-md-table-cell d-lg-table-cell">Capacidad</th>
                             <th class="d-none d-sm-none d-md-table-cell d-lg-table-cell">Horas</th>
                             <th>Estado</th>
+                            <th>Cargar Asistencia</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -70,6 +71,9 @@
                                 <td>
                                     <x-eventstatus :event="$event"/>
                                 </td>
+                                <td><a href="{{route('registercoordinator.attendee.load',['instance' => $instance, 'id' => $event->id_eventbrite])}}"
+                                    class="btn btn-primary btn-block" role="button">
+                                    <i class="fas fa-cloud-download-alt"></i></a></td>
                             </tr>
                         @endforeach
                         </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -331,7 +331,7 @@ Route::group(['prefix' => '{instance}', 'middleware' => ['checkblock']], functio
         Route::post('/registercoordinator/token/save', 'EventbriteController@token_save')->name('registercoordinator.token.save');
 
         Route::get('/registercoordinator/event/load', 'EventbriteController@event_load')->name('registercoordinator.event.load');
-        Route::get('/registercoordinator/attendee/load', 'EventbriteController@attendee_load')->name('registercoordinator.attendee.load');
+        Route::get('/registercoordinator/attendee/load/{id}', 'EventbriteController@attendee_load')->name('registercoordinator.attendee.load');
     });
 
     Route::get('/registercoordinator/event/list','EventbriteController@event_list')->name('registercoordinator.event.list');


### PR DESCRIPTION
Se ha modificado la obtención de las asistencias a través de la API de eventbrite.
Antes:
- Se cargaban todas las asistencias de todos los eventos a la vez, lo que hacía que el servidor tardara mucho en responder, muchas veces devolviendo errores 500.

Ahora:
- Se ha añadido una columna a cada evento para cargar las asistencias de ese único evento, de manera que cada vez que se presiona el botón, se eliminan las asistencias anteriores de dicho evento y se almacenan las que vienen de la API. Esto mejora mucho más la gestión ya que se libera un poco más la carga de las llamadas. 
